### PR TITLE
redesign av KildesystemIdenfikator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Gjøres med 'workflows' og 'actions' fra GitHub. Se `.github/workflows/*` for de
 
 versjon | endringstype | beskrivelse
 --------|--------------|------------
+0.3.0   | endret       | `KildesystemIdentifikator`: value bean uten statisk tilstand
+0.3.0   | endret       | `KildesystemIdentifikator`: Forholder setg ikke til heltallstype ved sjekking av gyldighet (long vs integer)
 0.2.1   | endret       | Fjernet skadelige avhengigheter rapportert av snyk.io
 0.2.0   | -- ingen --  | Overgang til bruk av github som maven-repo
 0.1.18  | endret       | `ExceptionLogger`: Exception med massage blir printet først i meldingene som logges

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>no.nav.bidrag</groupId>
   <artifactId>bidrag-commons</artifactId>
-  <version>0.2.2-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <licenses>

--- a/src/test/java/no/nav/bidrag/commons/KildesystemIdenfikatorTest.java
+++ b/src/test/java/no/nav/bidrag/commons/KildesystemIdenfikatorTest.java
@@ -3,29 +3,71 @@ package no.nav.bidrag.commons;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import no.nav.bidrag.commons.KildesystemIdenfikator.Kildesystem;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class KildesystemIdenfikatorTest {
 
   @Test
-  @DisplayName("skal validere prefix for tråd")
+  @DisplayName("skal validere prefix")
   void skalValiderePrefix() {
     assertAll(
-        () -> assertThat(KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix(null)).as("null").isTrue(),
-        () -> assertThat(KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix("123")).as("ingen prefix").isTrue(),
-        () -> assertThat(KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix("NA-123")).as("ukjent prefix").isTrue(),
-        () -> assertThat(KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix("BID-xyz")).as("ikke tall").isTrue(),
-        () -> assertThat(KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix("BID-123")).as("bidrag prefix").isFalse(),
-        () -> assertThat(KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix("JOARK-123")).as("joark prefix").isFalse()
+        () -> assertPrefix("123", "Mangler prefix", PrefixIdent.UGYLDIG),
+        () -> assertPrefix("NA-123", "ukjent prefix", PrefixIdent.UGYLDIG),
+        () -> assertPrefix("BID-xyz", "ikke tall", PrefixIdent.UGYLDIG),
+        () -> assertPrefix("BID-123", "bidrag prefix", PrefixIdent.GYLDIG),
+        () -> assertPrefix("JOARK-123", "joark prefix", PrefixIdent.GYLDIG)
     );
+  }
+
+  private void assertPrefix(String identifikator, String beskrivelse, PrefixIdent prefixIdent) {
+    assertThat(new KildesystemIdenfikator(identifikator).erUkjentPrefixEllerHarIkkeTallEtterPrefix()).as(beskrivelse)
+        .isEqualTo(prefixIdent.erUgyldig());
+  }
+
+  private enum PrefixIdent {
+    GYLDIG, UGYLDIG;
+
+    boolean erUgyldig() {
+      return this == UGYLDIG;
+    }
   }
 
   @Test
   void skalHenteJournalpostId() {
-    KildesystemIdenfikator.erUkjentPrefixEllerHarIkkeTallEtterPrefix("BID-666");
-    Integer journalpostId = KildesystemIdenfikator.hentJournalpostId();
+    KildesystemIdenfikator kildesystemIdenfikator = new KildesystemIdenfikator("BID-666");
 
-    assertThat(journalpostId).isEqualTo(666);
+    assertThat(kildesystemIdenfikator.hentJournalpostId()).isEqualTo(666);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "BID-3757282865", // journalpost Id er ikke gyldig (Long), men det er et gyldig prefix på et tall - henter integer som null (!!!)
+      "BID-3757282443", // journalpost Id er ikke gyldig (Long), men det er et gyldig prefix på et tall - henter integer som null (!!!)
+      "BID-37576108"
+  })
+  @DisplayName("skal ikke være ugyldige kildesystemidentifikatorer")
+  void skalIkkeVaereUgyldig(String identifikator) {
+    assertThat(new KildesystemIdenfikator(identifikator).erUkjentPrefixEllerHarIkkeTallEtterPrefix())
+        .as("er %s gyldig", identifikator).isEqualTo(false);
+  }
+
+  @Test
+  @DisplayName("skal hente kildesystem")
+  void skalHenteKildesystem() {
+    assertAll(
+        () -> assertKildesystem(new KildesystemIdenfikator("joark-2"), Kildesystem.JOARK),
+        () -> assertKildesystem(new KildesystemIdenfikator("bid-123456789012345"), Kildesystem.BIDRAG)
+    );
+  }
+
+  private void assertKildesystem(KildesystemIdenfikator kildesystemIdenfikator, Kildesystem kildesystem) {
+    assertAll(
+        () -> assertThat(kildesystemIdenfikator.getKildesystem()).as(kildesystemIdenfikator.getPrefiksetJournalpostId()).isEqualTo(kildesystem),
+        () -> assertThat(kildesystemIdenfikator.erFor(kildesystem)).as(kildesystemIdenfikator.getPrefiksetJournalpostId()).isTrue()
+    );
   }
 }


### PR DESCRIPTION
- en value bean vs statisk verdi håndtering
- bruker ikke Integer for å validere gyldig journalpostId med prefix