### PR TITLE
ny release som begrenser logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Gjøres med 'workflows' og 'actions' fra GitHub. Se `.github/workflows/*` for de
 
 versjon | endringstype | beskrivelse
 --------|--------------|------------
+0.3.2   | endret       | `HttpHeaderRestTemplate`: Logger header names (ikke values)
+0.3.2   | endret       | `SoapSamlCallback`: Logger ikke SOAP message
 0.3.1   | endret       | `HttpHeaderRestTemplate`: Logger masked Authorization header
 0.3.0   | endret       | `KildesystemIdentifikator`: value bean uten statisk tilstand
 0.3.0   | endret       | `KildesystemIdentifikator`: Forholder setg ikke til heltallstype ved sjekking av gyldighet (long vs integer)

--- a/src/main/java/no/nav/bidrag/commons/web/HttpHeaderRestTemplate.java
+++ b/src/main/java/no/nav/bidrag/commons/web/HttpHeaderRestTemplate.java
@@ -2,8 +2,10 @@ package no.nav.bidrag.commons.web;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
@@ -38,22 +40,17 @@ public class HttpHeaderRestTemplate extends RestTemplate {
     }
 
     HttpEntity<T> httpEntity = newEntityWithAdditionalHttpHeaders(requestBody);
-    httpEntity.getHeaders().forEach(this::logButNotAuthorization);
+    Set<String> headerNames = new HashSet<>(headerGenerators.keySet());
+    LOGGER.info("Generate header(s): {}", headerNames);
 
     return super.httpEntityCallback(httpEntity, responseType);
-  }
-
-  private void logButNotAuthorization(String name, List<String> values) {
-    if (HttpHeaders.AUTHORIZATION.equals(name)) {
-      LOGGER.info("Using {}: ****", name);
-    } else {
-      LOGGER.info("Using {}: {}", name, values.get(0));
-    }
   }
 
   private <T> HttpEntity<T> newEntityWithAdditionalHttpHeaders(Object o) {
     if (o != null) {
       HttpEntity<T> httpEntity = mapToHttpEntity(o);
+      Set<String> headerNames = new HashSet<>(httpEntity.getHeaders().keySet());
+      LOGGER.info("Existing header(s): {}", headerNames);
       return new HttpEntity<>(httpEntity.getBody(), combineHeaders(httpEntity.getHeaders()));
     }
 

--- a/src/main/java/no/nav/bidrag/commons/ws/SoapSamlCallback.java
+++ b/src/main/java/no/nav/bidrag/commons/ws/SoapSamlCallback.java
@@ -30,7 +30,7 @@ import org.xml.sax.InputSource;
 public class SoapSamlCallback extends SoapActionCallback {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SoapSamlCallback.class);
-  private static final String WSSE_NS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+  static final String WSSE_NS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
 
   private String samlAssertion;
   private Exception error;
@@ -62,7 +62,9 @@ public class SoapSamlCallback extends SoapActionCallback {
     result.getNode().appendChild(node);
 
     try {
-      LOGGER.debug("SOAP Message\n" + transformToString(soapMessage.getDocument()));
+      var transformed = transformToString(soapMessage.getDocument());
+      int index = transformed.indexOf('>');
+      LOGGER.debug("SOAP Message med SAML token fra {}: {}{}", WSSE_NS, transformed.substring(0, index), "...");
     } catch (TransformerException e) {
       LOGGER.error("Unable to append saml token", e);
     }
@@ -74,7 +76,9 @@ public class SoapSamlCallback extends SoapActionCallback {
       documentBuilderFactory.setNamespaceAware(true);
       DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
       Document document = documentBuilder.parse(new InputSource(new StringReader(samlAssertion)));
-      LOGGER.debug("SAML\n" + transformToString(document));
+      var transformed = transformToString(document);
+      int index = transformed.indexOf('>');
+      LOGGER.debug("SAML assertion document: {}{}", transformed.substring(0, index), "...");
 
       return document;
     } catch (Exception e) {

--- a/src/test/java/no/nav/bidrag/commons/ws/SoapSamlCallbackTest.java
+++ b/src/test/java/no/nav/bidrag/commons/ws/SoapSamlCallbackTest.java
@@ -3,6 +3,7 @@ package no.nav.bidrag.commons.ws;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -136,7 +137,12 @@ class SoapSamlCallbackTest {
     assertThatNullPointerException().isThrownBy(() -> soapSamlCallback.doWithMessage(soapMessageMock));
 
     Set<String> logMsgs = fetchMessages(appenderMock);
-    assertThat(String.join("\n", logMsgs)).contains("SAML").contains("saml2:Assertion");
+    String allMsgs = String.join("\n", logMsgs);
+
+    assertAll(
+        () -> assertThat(allMsgs).contains("SAML").contains("assertion document"),
+        () -> assertThat(allMsgs).doesNotContain("SOAP Message").doesNotContain(SoapSamlCallback.WSSE_NS)
+    );
   }
 
   @Test
@@ -159,7 +165,7 @@ class SoapSamlCallbackTest {
     soapSamlCallback.doWithMessage(soapMessageMock);
 
     Set<String> logMsgs = fetchMessages(appenderMock);
-    assertThat(String.join("\n", logMsgs)).contains("SOAP Message").contains("saml2:Assertion");
+    assertThat(String.join("\n", logMsgs)).contains("SOAP Message").contains(SoapSamlCallback.WSSE_NS);
   }
 
   private Appender<ILoggingEvent> mockLogAppender() {
@@ -173,6 +179,7 @@ class SoapSamlCallbackTest {
     return appenderMock;
   }
 
+  @SuppressWarnings("rawtypes")
   private Set<String> fetchMessages(Appender appenderMock) {
     var msgs = new ArrayList<String>();
 


### PR DESCRIPTION
- HttpHeaderRestTemplate logger bare header names
- SoapSamlCallback logger ikke soap message